### PR TITLE
Update proposal per feedbacks

### DIFF
--- a/spec/Secure Debug Proposal.md
+++ b/spec/Secure Debug Proposal.md
@@ -22,7 +22,7 @@
 - The debug accesses except the ones from System Bus Block should be regulated according to the privilege levels (assigning a privilege level to debug access). 
 - Less privileged debug accesses cannot peep/interrupt the hart when it runs in higher privilege level (e.g., S mode debug privilege cannot read/halt the trap handler or context switch in M mode).
 - Less privileged debug accesses cannot tamper resources belongs to more privileged level (e.g., S mode debug privilege level to access M mode CSR or memory granted to M mode by PMP).
-- The debug access can be conditional enabled for the same privilege level. (e.g., both ROM and Non-ROM can live in M mode, but the debugability should be granted differently).
+- The debug access can be conditional enabled. (e.g., both ROM and Non-ROM can live in M mode, but the debugability should be granted differently).
 - Memory accesses from System Bus Block shall be regulated by IOPMP or something equivalent.
 
 ## Core changes
@@ -51,7 +51,7 @@ The encoding of dbgprv is shown below. Note that dbgv bit and dbgprv bits follow
 | Yes | 1 | 1 | 1 | VS/VU mode external debug enabled |
 
 
-> 💡 The default value of mdbgsec.dbgprv/mdbgsec.dbgen is implementation specific. Resetting it to 0 (all privilege levels disabled for debug) and letting FW or ROM code enable debug is the most secured way. But it means debugability is lost until it is enabled and halt-after-reset is also useless. A good practice to solve this problem is to use a life-cycle fuse that controls the default value of mdbgsec.dbgprv and mdbgsec.dbgen via an input port to the hart. Developers can debug ROM code in development phase and disable it afterwards. Moreover, when the WG extension is adopted, another set of fuses can be implemented to disable debug according to WID. For example, if the fuse for WID n is burnt, the mdbgsec.dbgen is switched to fixed value 0x0 when WID is set to n. As another WID is assigned, the mdbgsec.dbgen will be switched back.
+> 💡 The default value of mdbgsec.dbgprv/mdbgsec.dbgen is implementation specific. Resetting it to 0 (all privilege levels disabled for debug) and letting FW or ROM code enable debug is the most secured way. But it means debugability is lost until it is enabled and halt-after-reset is also useless. A good practice to solve this problem is to use a life-cycle fuse that controls the default value of mdbgsec.dbgprv and mdbgsec.dbgen via an input port to the hart. Developers can debug ROM code in development phase and disable it afterwards. Moreover, when the [WG extension](https://s3-us-west-1.amazonaws.com/groupsioattachments/57273/98544119/711/0?AWSAccessKeyId=AKIAJECNKOVMCCU3ATNQ&Expires=1692606236&Signature=L19Ea5l0s1gf6LiEvV71CY8UviU%3D&response-content-disposition=inline%3B+filename%3D%22worldguard_rvia_spec-v0.4.pdf%22) is adopted, another set of fuses can be implemented to disable debug according to WID. For example, if the fuse for WID n is burnt, the mdbgsec.dbgen is switched to fixed value 0x0 when WID is set to n. As another WID is assigned, the mdbgsec.dbgen will be switched back.
 
 > 💡 The M mode is responsible to manage its own debugability since it is the most privileged mode. The S mode debugability is granted by M mode. The secure monitor in M mode could enforce different policies for each S mode context during context switch, which constrains debug accesses within the debuggable partition. 
 
@@ -60,14 +60,17 @@ The encoding of dbgprv is shown below. Note that dbgv bit and dbgprv bits follow
 The following behaviors will be changed with debug security extension
 
 - Halt request behaviors changes as the following
-    - If debug is disabled in all modes, halt request will return security fault error （cmderr set to 6)
+    - if debug is disabled in all modes, halt request will return security fault error （cmderr set to 6)
     - if debug is enabled in any modes, halt request will be pending till the hart can be halted
-- Abstract commands accesses to memory and registers will be checked as if it is in privilege specified by dcsr.prv/dcsr.v. Exceptions will set cmderr to 3 (exception).
-- Programming buffer accesses to memory and registers will work as if the it is running at privilege level specified in dcsr.prv/dcsr.v. Exceptions will set cmderr to 3 (exception).
+- Abstract commands accesses to memory and registers will be checked as if it is in privilege specified by dcsr.prv/dcsr.v (with mstatus.mprv honored if dcsr.mprven is set). Exceptions will set cmderr to 3 (exception).
+- Program buffer accesses to memory and registers will work as if the it is running at privilege level specified in dcsr.prv/dcsr.v(with mstatus.mprv honored if dcsr.mprven is set). Exceptions will set cmderr to 3 (exception).
 - Writing dcsr.prv/dcsr.v with a value whose corresponding privilege level is disabled for debug will get security fault error.
 - hartreset/resethaltreq will get security fault error from selected hart if M mode debug is disabled.
-- setkeepalive will get security fault error from selected hart if M mode debug is disabled.
+- keepalive should be either ignored for all debug privilege levels or at least for sub-machine mode privilege levels.
 - If exceptions or interrupts occurs during single stepping that lands on higher privilege level with debug disabled, for example, S mode (debug enabled) trap into M mode (debug disabled), the hart will continue execution in higher privilege level, and re-enter debug mode immediately after returning debuggable privilege level.
+- relaxedpriv must be hardwired to 0x0 
+
+> 💡 relaxedpriv might bypass the permission check (e.g. PMP), which is not desired in security perspective. Thus, it has to be hardwired to 0x0 to enforce strict permission check policy. 
 
 > 💡 The halt group will halt all harts in the same group if anyone halts. There might be the case that different harts have varied debug control policies and some harts may not run in debuggable privilege levels. The halt requests issued by halt group will be pending till the hart enter a debuggable privilege level. 
    
@@ -88,16 +91,13 @@ Bits 8-11 of mdbgsec controls RISC-V trace
 
 > 💡 Similar to mdbgsec.dbgprv/mdbgsec.dbgen, the value of mdbgsec.trcprv/mdbgsec.trcen could be enforced by hardware fusing. 
  
-Bits 4-17 of mdbgsec:
+Bits 5-7 of mdbgsec:
 
 | Field          | Bit | Description                                                                                                          | Access         | Reset |
 | -------------- | --- | -------------------------------------------------------------------------------------------------------------------- | -------------- | ----- |
 | trclock        | 7   | 0: trcen, trcv, trcrprv are allowed to program <br> 1: trcen, trcv, trcprv values are locked and no more programable | Write 1 sticky | 0     |
 | dbglock        | 6   | 0: dbgen, dbgv, dbgprv are allowed to program <br> 1: dbgen, dbgv, dgbprv values are locked and no more programable  | Write 1 sticky | 0     |
 | extrigdis      | 5   | 0: external triggers are enabled <br>1: external triggers are disabled                                               | R/W            | 0     |
-| relaxedprivdis | 4   | 0: relaxedpriv performs relaxed set of permission checks <br>1: relaxedpriv takes no effect                          | R/W            | 0     |
-
-> 💡 relaxedpriv may be useful when debugging ROM and M mode FW but it shall be disabled when debugging runtime software such as OS. In this case, we need a new knob to achieve the configuration that M mode debug is enabled but relaxedpriv is prohibited. ROM should make sure relaxedprivdis is set to 1 when a PMP entry is locked by setting pmpcfg*.L to 1. 
 
 ### Debug Control and Status (dcsr)
 
@@ -111,11 +111,16 @@ Core debug registers are still accessible in debug mode regardless of debug priv
 | ebeaks | Requires S mode debug |
 | ebreaku | Requires U mode debug |
 | stepie | Requires M mode debug |
-| stopcount  | Requires mdbgsec.dbgen == 1 |
 | stoptime | Requires M mode debug |
 | mprven | Requires M mode debug |
 | nmip | Requires M mode debug |
 | v, prv | Cannot exceed privilege defined in mdbgsec |
+
+The fields in dcsr require sufficient privilege level to access, otherwise the fields will be masked by 0x0 (mutiplexed to read-only zero if privilege not suffice, and switched back to be configurable fields if granted sufficient privilege).
+
+### Debug PC (dpc) and Debug Scratch Register (dscratch0, dscratch1)
+
+The CSR dpc, dscratch0 and dscratch1 is accessible when the hart enter a debuggable privilege level.
 
 ### Machine Debug Operation Control Register (MDBGOPCTL)
 
@@ -169,9 +174,12 @@ A subset of trigger programing registers are still accessible in debug mode rega
 
 The trigger module behaves differently with debug security extension as the following
 
-- Triggers with action = 1 (enter debug mode) will only fire if debug is enabled for corresponding privilege level.
+- Triggers with action = 1 (enter debug mode) will only match/fire if debug is enabled for the privilege level where the hart hits the trigger.
 - The trigger to start/stop/notify trace module succeeds only if the privilege level of the hart is enable for trace in mdbgctl.trcprv/mdbgctl.trcv.
-- In debug mode, triggers cannot be enabled for privilege levels higher than the one specified in mdbgsec.dbgprv/mdbgsec.dbgv.
+- In debug mode:
+    - triggers (action = 0/1) cannot be enabled for privilege levels higher than the one specified in mdbgsec.dbgprv/mdbgsec.dbgv.
+    - triggers (action = 2/3/4) cannot be enabled for privilege levels higher than the one specified in mdbgsec.trcprv/mdbgsec.trcv.
+    - triggers (action = 8/9) cannot be enabled if mdbgsec.extrigdis is zero.
 - If the trigger is already enabled for higher privilege level (by hart) than the ones allowed in mdbgsec, it could not be altered in debug mode and tdata1/2/3 return 0x0 in read accesses.
 
 > 💡 There might be the cases, though rare, that native debugger and external debugger co-exists. The native debugger might set a trigger in high privilege level while external debugger is restricted to relative low privilege level accessibility. This rule avoid that the external debugger corrupts the trigger setting in high privilege level of native debugger. Both debuggers should be orthogonal.


### PR DESCRIPTION
- Remove the relaxedprivdis by hardwiring relaxedpriv to 0x0
- Remove the rule for stopcout due to redundancy
- Modify the restriction for keepalive
- Add access policy dpc/dscrath0/dscratch1
- Elaborate on trace enable/disable, abstract command/progam buffer access privilege to avoid ambiguity
- Fix typos